### PR TITLE
Handling case when name option does not have an interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ exports.findExternalInterface = function findExternalInterface (options) {
   var name = options.name;
 
   if (name) {
-    return findInAddresses(networkInterfaces[name]) ? name : null;
+    return (networkInterfaces[name]) ? (findInAddresses(networkInterfaces[name]) ? name : null) : null;
   }
 
   return Object.keys(networkInterfaces)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -82,6 +82,19 @@ describe('findExternalInterface()', function () {
         expect(findExternalInterface({name: 'en14'})).to.be.null;
       });
     });
+    
+    describe('and there is no matching interface', function () {
+      beforeEach(function () {
+        var interfaces = Object.assign({}, allInterfaces);
+        interfaces.en14 = interfaces.en13;
+        sandbox.stub(os, 'networkInterfaces')
+          .returns(interfaces);
+      });
+
+      it('should return null', function () {
+        expect(findExternalInterface({name: 'en15'})).to.be.null;
+      });
+    });
   });
 
   describe('when "name" option is an empty string', function () {


### PR DESCRIPTION
Added check to return null when name option does not have a mapped interface, instead of calling findInAddresses.
Added test case for this scenario
closes issue #1 